### PR TITLE
CLM-6: Fix view privileges issue for Result Form. (#10)

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -585,5 +585,52 @@
 			<column name="multiset_name" type="varchar(255)" />
 		</addColumn>
 	</changeSet>
+   <!-- 	
+	<changeSet author="shujaat.ali" id="commonlabtest-2019-2019-9-4-10">
+	    <update tableName="role_privilege">
+	        <column name="privilege" value='Add CommonLabTest Results'/>
+	        <where>privilege='Add CommonLabTest results'</where>
+	    </update>
+    </changeSet> -->
+    
+    <changeSet author="shujaat.ali" id="commonlabtest-2019-2019-9-5-11">
+		<sql>
+			SET foreign_key_checks = 0; 
+			UPDATE privilege p LEFT JOIN role_privilege rp ON p.privilege = rp.privilege 
+			SET p.privilege = 'Add CommonLabTest Results' , rp.privilege ='Add CommonLabTest Results'
+			WHERE p.privilege ='Add CommonLabTest results';
+			SET foreign_key_checks = 1;
+		</sql>
+	</changeSet>
+	
+	   <changeSet author="shujaat.ali" id="commonlabtest-2019-2019-9-5-12">
+		<sql>
+			SET foreign_key_checks = 0; 
+			UPDATE privilege p LEFT JOIN role_privilege rp ON p.privilege = rp.privilege 
+			SET p.privilege = 'View CommonLabTest Results' , rp.privilege ='View CommonLabTest Results'
+			WHERE p.privilege ='View CommonLabTest results';
+			SET foreign_key_checks = 1;
+		</sql>
+	</changeSet>
+	
+	   <changeSet author="shujaat.ali" id="commonlabtest-2019-2019-9-5-13">
+		<sql>
+			SET foreign_key_checks = 0; 
+			UPDATE privilege p LEFT JOIN role_privilege rp ON p.privilege = rp.privilege 
+			SET p.privilege = 'Edit CommonLabTest Results' , rp.privilege ='Edit CommonLabTest Results'
+			WHERE p.privilege ='Edit CommonLabTest results';
+			SET foreign_key_checks = 1;
+		</sql>
+	</changeSet>
+	
+	<changeSet author="shujaat.ali" id="commonlabtest-2019-2019-9-5-14">
+		<sql>
+			SET foreign_key_checks = 0; 
+			UPDATE privilege p LEFT JOIN role_privilege rp ON p.privilege = rp.privilege 
+			SET p.privilege = 'Delete CommonLabTest Results' , rp.privilege ='Delete CommonLabTest Results'
+			WHERE p.privilege ='Delete CommonLabTest results';
+			SET foreign_key_checks = 1;
+		</sql>
+	</changeSet>
 
 </databaseChangeLog>

--- a/omod/src/main/webapp/addLabTestResult.jsp
+++ b/omod/src/main/webapp/addLabTestResult.jsp
@@ -1,6 +1,6 @@
 <%@ include file="/WEB-INF/template/include.jsp"%>
 <%@ include file="/WEB-INF/template/header.jsp"%>
-<openmrs:require privilege="View labTestResult" otherwise="/login.htm"
+<openmrs:require privilege="View CommonLabTest Results" otherwise="/login.htm"
 	redirect="/module/commonlabtest/addLabTestResult.form" />
 
 <openmrs:portlet url="patientHeader" id="patientDashboardHeader"
@@ -140,7 +140,7 @@ input[type=checkbox] {
 
 			<c:choose>
 				<c:when test="${update == false}">
-					<openmrs:require privilege="Add CommonLabTest results"
+					<openmrs:require privilege="Add CommonLabTest Results"
 						otherwise="/login.htm"
 						redirect="/module/commonlabtest/addLabTestResult.form" />
 					<legend class="scheduler-border">
@@ -148,7 +148,7 @@ input[type=checkbox] {
 					</legend>
 				</c:when>
 				<c:otherwise>
-					<openmrs:require privilege="Edit CommonLabTest results"
+					<openmrs:require privilege="Edit CommonLabTest Results"
 						otherwise="/login.htm"
 						redirect="/module/commonlabtest/addLabTestResult.form" />
 					<legend class="scheduler-border">
@@ -165,7 +165,7 @@ input[type=checkbox] {
 		</fieldset>
 		<br>
 		<c:if test="${update == true}">
-			<openmrs:hasPrivilege privilege="Delete CommonLabTest results">
+			<openmrs:hasPrivilege privilege="Delete CommonLabTest Results">
 				<fieldset class="scheduler-border">
 					<legend class="scheduler-border">
 						<spring:message code="commonlabtest.result.void" />

--- a/omod/src/main/webapp/portlets/patientLabTests.jsp
+++ b/omod/src/main/webapp/portlets/patientLabTests.jsp
@@ -103,7 +103,7 @@ tbody.collapse.in {
 					<openmrs:hasPrivilege privilege="View CommonLabTest Samples">
 					  <th>Manage Test Sample</th>
 					</openmrs:hasPrivilege>
-					 <openmrs:hasPrivilege privilege="View CommonLabTest results">
+					 <openmrs:hasPrivilege privilege="View CommonLabTest Results">
 					 <th>Test Result</th>
 					 <th>Result Date</th>
 					</openmrs:hasPrivilege>
@@ -142,7 +142,7 @@ tbody.collapse.in {
 			       </div>
        			 </fieldset>
        		</openmrs:hasPrivilege>	
-       		<openmrs:hasPrivilege privilege="View CommonLabTest results">	 
+       		<openmrs:hasPrivilege privilege="View CommonLabTest Results">	 
        			  <!--Test Result Details -->
                <fieldset  class="scheduler-border">
       	 		  <legend  class="scheduler-border"><spring:message code="commonlabtest.result.detail" /></legend>
@@ -218,7 +218,7 @@ jQuery(document).ready(function () {
 		        resultsItems = resultsItems.concat('<openmrs:hasPrivilege privilege="View CommonLabTest Samples">');
 		        resultsItems = resultsItems.concat('<td> <span class="table-sample hvr-icon-grow" onclick="samplesTestOrder(this)"><img class="manImg hvr-icon" src="/openmrs/moduleResources/commonlabtest/img/testSample.png"></img></span></span></td>');
 		        resultsItems = resultsItems.concat('</openmrs:hasPrivilege>');
-		        resultsItems = resultsItems.concat('<openmrs:hasPrivilege privilege="View CommonLabTest results">');
+		        resultsItems = resultsItems.concat('<openmrs:hasPrivilege privilege="View CommonLabTest Results">');
 		        if(this.resultFilled){
 		          resultsItems = resultsItems.concat('<td> <span class="table-result hvr-icon-grow" onclick="resultsTestOrder(this)"><img class="manImg hvr-icon" src="/openmrs/moduleResources/commonlabtest/img/testResult.png"></img></span></span><span style="margin-left: 35px">  </span><img class="manImg hvr-icon" src="/openmrs/moduleResources/commonlabtest/img/greenchecked.png"></img></td>');
 		        }else{
@@ -417,7 +417,7 @@ function autoHide(){
 			  <openmrs:hasPrivilege privilege="View CommonLabTest Samples">
 			  		renderTestSample(parseData['sample']);
 			  </openmrs:hasPrivilege>
-			<openmrs:hasPrivilege privilege="View CommonLabTest results">
+			<openmrs:hasPrivilege privilege="View CommonLabTest Results">
 		       // renderTestResult(parseData['result'])
 		        renderResult(parseData['result']);
 		    </openmrs:hasPrivilege>


### PR DESCRIPTION
* Resolved the view previleges. The issue was due to incorrect privelliges added in result form.
Jira ticket link https://issues.openmrs.org/browse/CLM-6

* Resolved the view previleges issue.The issue was due to incorrect privelliges
added in result form.
Jira ticket link https://issues.openmrs.org/browse/CLM-6

Co-authored-by: shujaat.ali <shujaat.ali@ihsinformatics.com>